### PR TITLE
refactor: slackHistory 삭제 여부 검증 추가

### DIFF
--- a/slack/src/main/java/com/sparta/slack/domain/service/SlackService.java
+++ b/slack/src/main/java/com/sparta/slack/domain/service/SlackService.java
@@ -51,6 +51,8 @@ public class SlackService {
                         () -> new IllegalArgumentException(SlackExceptionMessage.SLACK_HISTORY_NOT_FOUND.getMessage())
                 );
 
+        validateDeleted(slackHistory);
+
         return SlackHistoryResponseDto.builder()
                 .slackHistoryId(slackHistory.getSlackHistoryId())
                 .username(slackHistory.getUsername())
@@ -69,6 +71,8 @@ public class SlackService {
                         () -> new IllegalArgumentException(SlackExceptionMessage.SLACK_HISTORY_NOT_FOUND.getMessage())
                 );
 
+        validateDeleted(slackHistory);
+
         slackHistory.updateMessage(requestDto.getMessage());
 
         return SlackHistoryIdResponseDto.builder()
@@ -85,6 +89,8 @@ public class SlackService {
                         () -> new IllegalArgumentException(SlackExceptionMessage.SLACK_HISTORY_NOT_FOUND.getMessage())
                 );
 
+        validateDeleted(slackHistory);
+
         slackHistory.updateDeleted(requestUsername);
 
         return SlackHistoryIdResponseDto.builder()
@@ -95,6 +101,12 @@ public class SlackService {
     private void validateRequestRole(String requestRole) {
         if (!requestRole.equals("MASTER")) {
             throw new IllegalArgumentException(SlackExceptionMessage.NOT_ALLOWED_API.getMessage());
+        }
+    }
+
+    private void validateDeleted(SlackHistory slackHistory) {
+        if (slackHistory.isDeleted()) {
+            throw new IllegalArgumentException(SlackExceptionMessage.DELETED_SLACK_HISTORY.getMessage());
         }
     }
 }

--- a/slack/src/main/java/com/sparta/slack/exception/SlackExceptionMessage.java
+++ b/slack/src/main/java/com/sparta/slack/exception/SlackExceptionMessage.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SlackExceptionMessage {
     SLACK_HISTORY_NOT_FOUND("존재하지 않는 슬랙 메시지 기록입니다."),
+    DELETED_SLACK_HISTORY("삭제된 슬랙 메시지 기록입니다."),
     NOT_ALLOWED_API("접근 권한이 없습니다.");
 
     private final String message;


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

### 반영 브랜치
- feature/slack-api -> develop

### 변경 사항
- SlackService에서 slackHistory 삭제 여부 검증하는 메서드 추가
- get, update, delete 메서드에서 검증을 진행하도록 로직 변경