### PR TITLE
feat: 슬랙 메시지 기록 검색 기능 구현

### DIFF
--- a/slack/build.gradle
+++ b/slack/build.gradle
@@ -34,6 +34,13 @@ dependencies {
 	// jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.jetbrains:annotations:24.1.0'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/slack/src/main/java/com/sparta/slack/config/QueryDslConfig.java
+++ b/slack/src/main/java/com/sparta/slack/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.sparta.slack.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jPAQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/slack/src/main/java/com/sparta/slack/domain/controller/SlackController.java
+++ b/slack/src/main/java/com/sparta/slack/domain/controller/SlackController.java
@@ -7,6 +7,9 @@ import com.sparta.slack.domain.dto.response.SlackHistoryResponseDto;
 import com.sparta.slack.domain.service.SlackService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -44,6 +48,17 @@ public class SlackController {
         SlackHistoryResponseDto responseDto = slackService.getSlackHistory(slackHistoryId, requestRole);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<PagedModel<SlackHistoryResponseDto>> getSlackHistories(
+            @RequestParam(required = false) String recievedSlackId,
+            Pageable pageable,
+            @RequestHeader("X-User-Role") String requestRole) {
+
+        Page<SlackHistoryResponseDto> responseDtos = slackService.getSlackHistories(recievedSlackId, pageable, requestRole);
+
+        return ResponseEntity.status(HttpStatus.OK).body(new PagedModel<>(responseDtos));
     }
 
     @PutMapping("/{slackHistoryId}")

--- a/slack/src/main/java/com/sparta/slack/domain/dto/response/SlackHistoryResponseDto.java
+++ b/slack/src/main/java/com/sparta/slack/domain/dto/response/SlackHistoryResponseDto.java
@@ -1,16 +1,26 @@
 package com.sparta.slack.domain.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class SlackHistoryResponseDto {
     private UUID slackHistoryId;
     private String username;
     private String recivedSlackId;
     private String message;
     private LocalDateTime sentAt;
+
+    @Builder
+    @QueryProjection
+    public SlackHistoryResponseDto(UUID slackHistoryId, String username, String recivedSlackId, String message, LocalDateTime sentAt) {
+        this.slackHistoryId = slackHistoryId;
+        this.username = username;
+        this.recivedSlackId = recivedSlackId;
+        this.message = message;
+        this.sentAt = sentAt;
+    }
 }

--- a/slack/src/main/java/com/sparta/slack/domain/service/SlackService.java
+++ b/slack/src/main/java/com/sparta/slack/domain/service/SlackService.java
@@ -11,6 +11,8 @@ import com.sparta.slack.model.repository.SlackRepository;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,6 +62,12 @@ public class SlackService {
                 .message(slackHistory.getMessage())
                 .sentAt(slackHistory.getSentAt())
                 .build();
+    }
+
+    public Page<SlackHistoryResponseDto> getSlackHistories(String recievedSlackId, Pageable pageable, String requestRole) {
+        validateRequestRole(requestRole);
+
+        return slackRepository.searchSlackHistories(recievedSlackId, pageable);
     }
 
     @Transactional

--- a/slack/src/main/java/com/sparta/slack/model/repository/SlackHistoryRepositoryCustom.java
+++ b/slack/src/main/java/com/sparta/slack/model/repository/SlackHistoryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.sparta.slack.model.repository;
+
+import com.sparta.slack.domain.dto.response.SlackHistoryResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SlackHistoryRepositoryCustom {
+    Page<SlackHistoryResponseDto> searchSlackHistories(String recievedSlackId, Pageable pageable);
+}
+

--- a/slack/src/main/java/com/sparta/slack/model/repository/SlackHistoryRepositoryCustomImpl.java
+++ b/slack/src/main/java/com/sparta/slack/model/repository/SlackHistoryRepositoryCustomImpl.java
@@ -1,0 +1,65 @@
+package com.sparta.slack.model.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.slack.domain.dto.response.QSlackHistoryResponseDto;
+import com.sparta.slack.domain.dto.response.SlackHistoryResponseDto;
+import com.sparta.slack.model.entity.QSlackHistory;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+public class SlackHistoryRepositoryCustomImpl implements SlackHistoryRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public SlackHistoryRepositoryCustomImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<SlackHistoryResponseDto> searchSlackHistories(String recievedSlackId, Pageable pageable) {
+        QSlackHistory slackHistory = QSlackHistory.slackHistory;
+
+        // QueryDSL 쿼리 작성
+        List<SlackHistoryResponseDto> content = queryFactory
+                .select(new QSlackHistoryResponseDto(
+                        slackHistory.slackHistoryId,
+                        slackHistory.username,
+                        slackHistory.recievedSlackId,
+                        slackHistory.message,
+                        slackHistory.sentAt
+                ))
+                .from(slackHistory)
+                .where(
+                        recievedSlackIdContains(recievedSlackId),
+                        isNotDeleted()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // Total count 쿼리
+        long total = Optional.ofNullable(
+                queryFactory
+                        .select(slackHistory.count())
+                        .from(slackHistory)
+                        .where(
+                                recievedSlackIdContains(recievedSlackId),
+                                isNotDeleted()
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> total);
+    }
+
+    private BooleanExpression recievedSlackIdContains(String recievedSlackId) {
+        return recievedSlackId != null ? QSlackHistory.slackHistory.recievedSlackId.contains(recievedSlackId) : null;
+    }
+
+    private BooleanExpression isNotDeleted() {
+        return QSlackHistory.slackHistory.deleted.eq(false);
+    }
+}

--- a/slack/src/main/java/com/sparta/slack/model/repository/SlackRepository.java
+++ b/slack/src/main/java/com/sparta/slack/model/repository/SlackRepository.java
@@ -4,5 +4,5 @@ import com.sparta.slack.model.entity.SlackHistory;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SlackRepository extends JpaRepository<SlackHistory, UUID> {
+public interface SlackRepository extends JpaRepository<SlackHistory, UUID>, SlackHistoryRepositoryCustom {
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

### 반영 브랜치
- feature/{도메인}-api -> main

### 변경 사항
- QueryDsl을 통해 수신자 슬랙 ID를 기반으로 검색하는 기능 구현