### PR TITLE
refactor: Slack 검색 API 리팩토링 및 zipkin 의존성 추가

### DIFF
--- a/slack/build.gradle
+++ b/slack/build.gradle
@@ -41,6 +41,12 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	implementation 'org.jetbrains:annotations:24.1.0'
 
+	// zipkin
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.github.openfeign:feign-micrometer'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/slack/src/main/java/com/sparta/slack/domain/controller/SlackController.java
+++ b/slack/src/main/java/com/sparta/slack/domain/controller/SlackController.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -53,7 +54,7 @@ public class SlackController {
     @GetMapping
     public ResponseEntity<PagedModel<SlackHistoryResponseDto>> getSlackHistories(
             @RequestParam(required = false) String recievedSlackId,
-            Pageable pageable,
+            @PageableDefault(sort = "createdAt") Pageable pageable,
             @RequestHeader("X-User-Role") String requestRole) {
 
         Page<SlackHistoryResponseDto> responseDtos = slackService.getSlackHistories(recievedSlackId, pageable, requestRole);

--- a/slack/src/main/java/com/sparta/slack/model/repository/SlackHistoryRepositoryCustomImpl.java
+++ b/slack/src/main/java/com/sparta/slack/model/repository/SlackHistoryRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.sparta.slack.model.repository;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sparta.slack.domain.dto.response.QSlackHistoryResponseDto;
@@ -8,6 +9,7 @@ import com.sparta.slack.model.entity.QSlackHistory;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
@@ -20,6 +22,8 @@ public class SlackHistoryRepositoryCustomImpl implements SlackHistoryRepositoryC
 
     @Override
     public Page<SlackHistoryResponseDto> searchSlackHistories(String recievedSlackId, Pageable pageable) {
+        Pageable validatedPageable = validatePageable(pageable);
+
         QSlackHistory slackHistory = QSlackHistory.slackHistory;
 
         // QueryDSL 쿼리 작성
@@ -36,8 +40,23 @@ public class SlackHistoryRepositoryCustomImpl implements SlackHistoryRepositoryC
                         recievedSlackIdContains(recievedSlackId),
                         isNotDeleted()
                 )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .orderBy(validatedPageable.getSort().stream()
+                        .map(order -> {
+                            if ("createdAt".equals(order.getProperty())) {
+                                return order.isAscending()
+                                        ? slackHistory.createdAt.asc()
+                                        : slackHistory.createdAt.desc();
+                            } else if ("lastModifiedAt".equals(order.getProperty())) {
+                                return order.isAscending()
+                                        ? slackHistory.lastModifiedAt.asc()
+                                        : slackHistory.lastModifiedAt.desc();
+                            } else {
+                                throw new IllegalArgumentException("정렬 옵션이 잘못되었습니다: " + order.getProperty());
+                            }
+                        })
+                        .toArray(OrderSpecifier[]::new))
+                .offset(validatedPageable.getOffset())
+                .limit(validatedPageable.getPageSize())
                 .fetch();
 
         // Total count 쿼리
@@ -52,7 +71,7 @@ public class SlackHistoryRepositoryCustomImpl implements SlackHistoryRepositoryC
                         .fetchOne()
         ).orElse(0L);
 
-        return PageableExecutionUtils.getPage(content, pageable, () -> total);
+        return PageableExecutionUtils.getPage(content, validatedPageable, () -> total);
     }
 
     private BooleanExpression recievedSlackIdContains(String recievedSlackId) {
@@ -61,5 +80,14 @@ public class SlackHistoryRepositoryCustomImpl implements SlackHistoryRepositoryC
 
     private BooleanExpression isNotDeleted() {
         return QSlackHistory.slackHistory.deleted.eq(false);
+    }
+
+    private Pageable validatePageable(Pageable pageable) {
+        int size = pageable.getPageSize();
+        if (size != 10 && size != 30 && size != 50) {
+            // 유효하지 않은 경우 기본값 10으로 수정
+            return PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
+        }
+        return pageable;
     }
 }

--- a/slack/src/main/resources/application.yml
+++ b/slack/src/main/resources/application.yml
@@ -23,3 +23,11 @@ service:
 
 server:
   port: 19093
+
+management:
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"
+  tracing:
+    sampling:
+      probability: 1.0


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

### 반영 브랜치
- feature/slack-api -> develop

### 변경 사항
- 검색 API에 sort, page 옵션을 처리할 수 있도록 로직 변경
- zipkin 의존성 추가